### PR TITLE
Callable `Timestep`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -26,7 +26,6 @@ emit
 Timestep
 FixedTimestep
 RandomTimestep
-get_step
 ```
 
 ## Particle Filter

--- a/src/BinomialSynapses.jl
+++ b/src/BinomialSynapses.jl
@@ -23,7 +23,7 @@ include("propagate.jl")
 export propagate!
 
 include("timestep.jl")
-export Timestep, FixedTimestep, RandomTimestep, get_step, DeterministicTrain
+export Timestep, FixedTimestep, RandomTimestep, DeterministicTrain
 
 include("emission.jl")
 export emit

--- a/src/OED.jl
+++ b/src/OED.jl
@@ -13,14 +13,6 @@ Return the instance of OEDPolicy used in simulation `sim`.
 """
 policy(sim::NestedFilterSimulation) = sim.tsteps
 
-function get_step(sim::NestedFilterSimulation{T1, T2, T3, T4, T5, T6, T7}) where 
-{T1, T2, T3, T4, T5 <: OEDPolicy, T6, T7}
-    policy = sim.tsteps
-    return _oed!(sim, policy)
-end
-
-_oed!(sim, policy::OEDPolicy) = _oed!(policy)
-
 
 """
     Uniform(dts)
@@ -32,4 +24,4 @@ struct Uniform{T} <: OEDPolicy
     dts::T
 end
 
-_oed!(policy::Uniform) = rand(policy.dts)
+(policy::Uniform)() = rand(policy.dts)

--- a/src/myopic.jl
+++ b/src/myopic.jl
@@ -63,9 +63,7 @@ Minimize the entropy of τ.
 """
 MyopicFast_tau(dts) = MyopicFast(dts, _tauentropy)
 
-function _oed!(sim, ::MyopicPolicy)
-    policy = sim.tsteps
-
+function (policy::MyopicPolicy)(sim::NestedFilterSimulation)
     obs = _synthetic_obs(sim, policy)
     temp_state = _temp_state(sim, policy)
 

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -98,7 +98,7 @@ function initialize!(sim::NestedFilterSimulation)
     return sim
 end
 
-get_step(sim::NestedFilterSimulation) = get_step(sim.tsteps)
+(ts::Timestep)(::NestedFilterSimulation) = ts()
 
 
 """
@@ -107,7 +107,7 @@ get_step(sim::NestedFilterSimulation) = get_step(sim.tsteps)
 Propagate the simulation, i.e. choose a time step and then propagate the simulation by it.
 """
 function propagate!(sim::NestedFilterSimulation)
-    dt = get_step(sim)
+    dt = sim.tsteps(sim)
     propagate!(sim, dt)
 end
 

--- a/src/timestep.jl
+++ b/src/timestep.jl
@@ -10,11 +10,11 @@ The following basic types are supported:
 abstract type Timestep end
 
 """
-    get_step(::Timestep)
+    (ts::Timestep)()
 
 Returns a value for the time step, based on the chosen method for choosing a time step.
 """
-function get_step(::Timestep) end
+function (ts::Timestep)() end
 
 """
     FixedTimestep(dt)
@@ -55,9 +55,6 @@ struct DeterministicTrain{T} <: Timestep
     end
 end
 
-get_step(timestep::FixedTimestep) = timestep.dt
-get_step(timestep::RandomTimestep) = rand(timestep.distribution)
-
-function get_step(timestep::DeterministicTrain)
-    isempty(timestep.stack) ? nothing : pop!(timestep.stack)
-end
+(timestep::FixedTimestep)() = timestep.dt
+(timestep::RandomTimestep)() = rand(timestep.distribution)
+(timestep::DeterministicTrain)() = isempty(timestep.stack) ? nothing : pop!(timestep.stack)

--- a/test/timestep.jl
+++ b/test/timestep.jl
@@ -2,18 +2,18 @@
     @info "Testing timestep.jl"
 
     timestep = FixedTimestep(0.3)
-    @test get_step(timestep) == 0.3
+    @test timestep() == 0.3
     @test_throws ErrorException FixedTimestep(-1)
 
     timestep = RandomTimestep(Exponential(0.5))
-    @test get_step(timestep) > 0
-    @test get_step(timestep) != get_step(timestep)
+    @test timestep() > 0
+    @test timestep() != timestep()
 
     timestep = DeterministicTrain([1,2,3])
-    @test get_step(timestep) == 1
-    @test get_step(timestep) == 2
-    @test get_step(timestep) == 3
-    @test isnothing(get_step(timestep))
+    @test timestep() == 1
+    @test timestep() == 2
+    @test timestep() == 3
+    @test isnothing(timestep())
 
     @test_throws ErrorException DeterministicTrain([1, 1, -1])
     @test_throws ErrorException DeterministicTrain([1, 0])


### PR DESCRIPTION
This changes the API for producing time steps. `get_step(timestep)` is replaced by `timestep()` and `get_step(sim)` by `timestep(sim)`. This allows to get rid of the awkward `_oed` and `_oed!` helper functions.

Closes #56 