### PR TITLE
Return value for time

### DIFF
--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -167,7 +167,7 @@ function run!(
         if plot_each_timestep
             posterior_plot(sim,i)
         end
-        update!(recording, sim, time) 
+        update!(recording, sim, time.time) 
     end
     save(recording)
     return sim.times, sim.epsps


### PR DESCRIPTION
When doing a = @timed xxx, a is going to be a structure containing (value = 2, time = 1.0e-7, bytes = 0, gctime = 0.0, gcstats = Base.GC_Diff(0, 0, 0, 0, 0, 0, 0, 0, 0)). Here, we are only interested in the object time.