### PR TITLE
Implement `_diffentropy` function

### DIFF
--- a/src/myopic.jl
+++ b/src/myopic.jl
@@ -14,6 +14,7 @@ are propagated in parallel.
 Implemented settings of `target`: choose time step such that it
 - `_entropy`: minimizes the joint entropy of the posterior distribution over parameters
 - `_tauentropy`: minimizes the marginal entropy of `τ`
+- `_diffentropy`: minimizes the joint differential entropy of the posterior distribution over parameters. This computes the covariance matrix of the joint distribution, and calculated the differential entropy of a multivariate Gaussian with that covariance matrix.
 """
 struct Myopic{T1, T2} <: MyopicPolicy
     dts::T1
@@ -28,6 +29,7 @@ MyopicFast` is the same as `Myopic`, except that instead of expanding states and
 Implemented settings of `target`: choose time step such that it
 - `_entropy`: minimizes the joint entropy of the posterior distribution over parameters
 - `_tauentropy`: minimizes the marginal entropy of `τ`
+- `_diffentropy`: minimizes the joint differential entropy of the posterior distribution over parameters. This computes the covariance matrix of the joint distribution, and calculated the differential entropy of a multivariate Gaussian with that covariance matrix.
 """
 struct MyopicFast{T1, T2} <: MyopicPolicy
     dts::T1


### PR DESCRIPTION
This PR adds `_diffentropy` as a cost function for the myopic policies.
Supersedes #74 

@Camille, let me test on the GPU before merging.
I will do the final merge after your review and my GPU tests pass.